### PR TITLE
Add host directory mounts for Docker, Tart, and libvirt backends

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,27 +27,53 @@ type RunnerConfig struct {
 	Tart       *TartImage    `yaml:"tart,omitempty"`
 }
 
+// DockerMount defines a bind mount for a Docker container.
+type DockerMount struct {
+	Source   string `yaml:"source"`
+	Target   string `yaml:"target"`
+	ReadOnly bool   `yaml:"read_only"`
+}
+
+// TartMount defines a shared directory for a Tart VM.
+// Name is passed as the --dir label; it becomes the subdirectory name
+// under the mount point inside the guest.
+type TartMount struct {
+	Name     string `yaml:"name"`
+	Source   string `yaml:"source"`
+	ReadOnly bool   `yaml:"read_only"`
+}
+
+// LibvirtMount defines a virtiofs host directory share for a libvirt VM.
+// The directory is exposed via virtiofs; the tag is derived from the source basename.
+// On Windows guests, VirtioFsSvc mounts it automatically as a drive letter.
+type LibvirtMount struct {
+	Source string `yaml:"source"`
+}
+
 // DockerImage configures a Docker-based runner.
 type DockerImage struct {
-	Image     string `yaml:"image"`
-	RunnerCmd string `yaml:"runner_cmd"`
+	Image     string        `yaml:"image"`
+	RunnerCmd string        `yaml:"runner_cmd"`
+	Mounts    []DockerMount `yaml:"mounts"`
 }
 
 // LibvirtImage configures a libvirt/QEMU-based runner.
 type LibvirtImage struct {
-	Path      string `yaml:"path"`
-	RunnerCmd string `yaml:"runner_cmd"`
-	Socket    string `yaml:"socket"`
-	CPUs      int    `yaml:"cpus"`
-	MemoryMB  int    `yaml:"memory"`
+	Path      string        `yaml:"path"`
+	RunnerCmd string        `yaml:"runner_cmd"`
+	Socket    string        `yaml:"socket"`
+	CPUs      int           `yaml:"cpus"`
+	MemoryMB  int           `yaml:"memory"`
+	Mount     *LibvirtMount `yaml:"mount"`
 }
 
 // TartImage configures a Tart-based runner (macOS/Linux on Apple Silicon).
 type TartImage struct {
-	Image     string `yaml:"image"` // OCI image or local VM name
-	RunnerCmd string `yaml:"runner_cmd"`
-	CPUs      int    `yaml:"cpus"`
-	MemoryMB  int    `yaml:"memory"`
+	Image     string      `yaml:"image"` // OCI image or local VM name
+	RunnerCmd string      `yaml:"runner_cmd"`
+	CPUs      int         `yaml:"cpus"`
+	MemoryMB  int         `yaml:"memory"`
+	Mounts    []TartMount `yaml:"mounts"`
 }
 
 // ProviderType returns which provisioner backend this runner uses.

--- a/config_test.go
+++ b/config_test.go
@@ -232,6 +232,105 @@ func TestLoadConfigRunnerCmd(t *testing.T) {
 	}
 }
 
+func TestLoadConfigMounts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+
+	content := `runners:
+  docker-runner:
+    labels: [linux]
+    docker:
+      image: runner:latest
+      mounts:
+        - source: /var/cache/vcpkg
+          target: /opt/vcpkg-cache
+        - source: /var/cache/cargo
+          target: /opt/cargo-cache
+          read_only: true
+  tart-runner:
+    labels: [macos]
+    tart:
+      image: base:latest
+      mounts:
+        - name: vcpkg
+          source: /var/cache/vcpkg
+        - name: cargo
+          source: /var/cache/cargo
+          read_only: true
+  windows-runner:
+    labels: [windows]
+    libvirt:
+      path: /images/win.qcow2
+      mount:
+        source: /var/cache/vcpkg
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	// Docker mounts
+	docker := cfg.Runners["docker-runner"].Docker
+	if len(docker.Mounts) != 2 {
+		t.Fatalf("expected 2 docker mounts, got %d", len(docker.Mounts))
+	}
+	if docker.Mounts[0].Source != "/var/cache/vcpkg" || docker.Mounts[0].Target != "/opt/vcpkg-cache" || docker.Mounts[0].ReadOnly {
+		t.Errorf("unexpected docker mount[0]: %+v", docker.Mounts[0])
+	}
+	if docker.Mounts[1].Source != "/var/cache/cargo" || docker.Mounts[1].Target != "/opt/cargo-cache" || !docker.Mounts[1].ReadOnly {
+		t.Errorf("unexpected docker mount[1]: %+v", docker.Mounts[1])
+	}
+
+	// Tart mounts
+	tart := cfg.Runners["tart-runner"].Tart
+	if len(tart.Mounts) != 2 {
+		t.Fatalf("expected 2 tart mounts, got %d", len(tart.Mounts))
+	}
+	if tart.Mounts[0].Name != "vcpkg" || tart.Mounts[0].Source != "/var/cache/vcpkg" || tart.Mounts[0].ReadOnly {
+		t.Errorf("unexpected tart mount[0]: %+v", tart.Mounts[0])
+	}
+	if tart.Mounts[1].Name != "cargo" || tart.Mounts[1].Source != "/var/cache/cargo" || !tart.Mounts[1].ReadOnly {
+		t.Errorf("unexpected tart mount[1]: %+v", tart.Mounts[1])
+	}
+
+	// Libvirt mount
+	libvirt := cfg.Runners["windows-runner"].Libvirt
+	if libvirt.Mount == nil {
+		t.Fatal("expected libvirt mount")
+	}
+	if libvirt.Mount.Source != "/var/cache/vcpkg" {
+		t.Errorf("unexpected libvirt mount source: %s", libvirt.Mount.Source)
+	}
+}
+
+func TestLoadConfigNoMounts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+
+	content := `runners:
+  linux:
+    labels: [linux]
+    docker:
+      image: runner:latest
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if mounts := cfg.Runners["linux"].Docker.Mounts; len(mounts) != 0 {
+		t.Errorf("expected no mounts, got %d", len(mounts))
+	}
+}
+
 func TestLoadConfigInvalidYAML(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yml")

--- a/docs/howto/mixed-backends.md
+++ b/docs/howto/mixed-backends.md
@@ -102,6 +102,40 @@ runners:
       image: macos-runner
 ```
 
+## Persistent Build Cache
+
+Each backend supports mounting a host directory into the runner environment. This is useful for a persistent build cache (e.g. package manager caches, compiler caches) that survives across ephemeral runners without being re-downloaded on every job.
+
+```yaml
+runners:
+  linux:
+    labels: [self-hosted, linux]
+    docker:
+      image: outrunner-runner:latest
+      mounts:
+        - source: /var/cache/build
+          target: /opt/build-cache
+
+  windows:
+    labels: [self-hosted, windows]
+    libvirt:
+      path: /images/windows-builder.qcow2
+      runner_cmd: 'C:\actions-runner\run.cmd'
+      mount:
+        source: /var/cache/build   # appears as a drive letter (e.g. Z:) in Windows
+
+  macos:
+    labels: [self-hosted, macos]
+    tart:
+      image: macos-runner
+      runner_cmd: /actions-runner/run.sh
+      mounts:
+        - name: build-cache        # accessible at /Volumes/My Shared Files/build-cache
+          source: /var/cache/build
+```
+
+See the [provisioners reference](../reference/provisioners.md) for backend-specific details on how the mounts appear inside the runner.
+
 ## Platform Constraints
 
 Not all backends work on all hosts:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -15,17 +15,27 @@ runners:
     docker:                          # Use Docker backend.
       image: <string>                # Docker image name or tag.
       runner_cmd: <string>           # Default: ./run.sh
+      mounts:                        # Optional bind mounts.
+        - source: <string>           # Host path.
+          target: <string>           # Container path.
+          read_only: <bool>          # Default: false
     libvirt:                         # Use libvirt/KVM backend.
       path: <string>                 # Path to the base qcow2 disk image.
       runner_cmd: <string>           # Default: /actions-runner/run.sh
       socket: <string>               # Default: /var/run/libvirt/libvirt-sock
       cpus: <int>                    # Default: 4
       memory: <int>                  # Default: 8192 (MiB)
+      mount:                         # Optional virtiofs host directory share.
+        source: <string>             # Host path. Tag is derived from the basename.
     tart:                            # Use Tart backend.
       image: <string>                # OCI image URL or local VM name.
       runner_cmd: <string>           # Default: /actions-runner/run.sh
       cpus: <int>                    # Default: 4
       memory: <int>                  # Default: 8192 (MiB)
+      mounts:                        # Optional shared directories (--dir).
+        - name: <string>             # Directory name inside the guest.
+          source: <string>           # Host path.
+          read_only: <bool>          # Default: false
 ```
 
 ## Top-Level Fields
@@ -90,8 +100,17 @@ Provisions a Docker container per job.
 |-------|------|---------|-------------|
 | `image` | string | (required) | Docker image reference. Can be a local tag (`runner:latest`) or a registry reference (`ghcr.io/org/runner:v1`). |
 | `runner_cmd` | string | `./run.sh` | Command to start the runner inside the container. |
+| `mounts` | list | `[]` | Bind mounts to attach to the container. See below. |
 
 The container runs `<runner_cmd> --jitconfig <config>` as its command. The image must have the GitHub Actions runner installed at the working directory. See [Image Requirements](image-requirements.md).
+
+**`mounts` entries:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `source` | string | (required) | Absolute path on the host. |
+| `target` | string | (required) | Absolute path inside the container. |
+| `read_only` | bool | `false` | Mount read-only. |
 
 ### `runners.<name>.libvirt`
 
@@ -104,6 +123,15 @@ Provisions a KVM/QEMU virtual machine per job using a copy-on-write overlay.
 | `socket` | string | `/var/run/libvirt/libvirt-sock` | Path to the libvirtd Unix socket. |
 | `cpus` | int | `4` | Number of vCPUs allocated to the VM. |
 | `memory` | int | `8192` | Memory in MiB allocated to the VM. |
+| `mount` | object | (none) | Optional virtiofs host directory share. See below. |
+
+**`mount` fields:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `source` | string | (required) | Absolute path on the host to share into the VM. The virtiofs tag is derived from the directory basename. |
+
+The share is exposed via virtiofs. On Windows guests, `VirtioFsSvc` mounts it automatically as a drive letter (requires WinFsp installed in the guest image). `virtiofsd` must be installed on the host (`apt install virtiofsd`).
 
 ### `runners.<name>.tart`
 
@@ -115,6 +143,15 @@ Provisions a Tart virtual machine per job by cloning from a base image.
 | `runner_cmd` | string | `/actions-runner/run.sh` | Command to execute inside the VM via `tart exec`. |
 | `cpus` | int | `4` | Number of vCPUs allocated to the VM. |
 | `memory` | int | `8192` | Memory in MiB allocated to the VM. |
+| `mounts` | list | `[]` | Shared directories passed to `tart run --dir`. See below. |
+
+**`mounts` entries:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | string | (required) | Directory name as it appears inside the guest. On macOS guests this is a subdirectory of `/Volumes/My Shared Files/`; on Linux guests mount the share manually with `mount -t virtiofs com.apple.virtio-fs.automount <mountpoint>`. |
+| `source` | string | (required) | Absolute path on the host. |
+| `read_only` | bool | `false` | Mount read-only. |
 
 ## Examples
 
@@ -131,7 +168,7 @@ runners:
       image: outrunner-runner:latest
 ```
 
-Mixed backends:
+Mixed backends with shared cache:
 
 ```yaml
 url: https://github.com/myorg
@@ -143,6 +180,9 @@ runners:
     max_runners: 4
     docker:
       image: outrunner-runner:latest
+      mounts:
+        - source: /var/cache/vcpkg
+          target: /opt/vcpkg-cache
 
   windows:
     labels: [self-hosted, windows]
@@ -152,6 +192,8 @@ runners:
       runner_cmd: 'C:\actions-runner\run.cmd'
       cpus: 4
       memory: 8192
+      mount:
+        source: /var/cache/vcpkg
 
   macos:
     labels: [self-hosted, macos]
@@ -161,4 +203,7 @@ runners:
       runner_cmd: /Users/admin/actions-runner/run.sh
       cpus: 4
       memory: 8192
+      mounts:
+        - name: vcpkg
+          source: /var/cache/vcpkg
 ```

--- a/docs/reference/provisioners.md
+++ b/docs/reference/provisioners.md
@@ -26,6 +26,18 @@ If `DOCKER_HOST` is not set, outrunner runs `docker context inspect` to find the
 
 The detected socket path is verified to exist before use.
 
+### Bind Mounts
+
+The `mounts` config field attaches host directories into each container as bind mounts. This is useful for a persistent build cache that survives across ephemeral containers without being downloaded each run.
+
+```yaml
+docker:
+  image: outrunner-runner:latest
+  mounts:
+    - source: /var/cache/vcpkg
+      target: /opt/vcpkg-cache
+```
+
 ### Requirements
 
 - Docker Engine or compatible runtime
@@ -62,6 +74,23 @@ VMs are created with:
 - **Network:** virtio NIC on the configured libvirt network (default: `default`)
 - **Guest agent:** virtio-serial channel (`org.qemu.guest_agent.0`)
 - **Console:** Serial + console (for debugging via `virsh console`)
+
+### virtiofs Mount
+
+The `mount` config field shares a host directory into the VM via virtiofs. This is the recommended approach for a persistent build cache — the host directory is accessible at near-native speed without any network round-trip.
+
+```yaml
+libvirt:
+  path: /images/windows-builder.qcow2
+  mount:
+    source: /var/cache/vcpkg
+```
+
+The virtiofs tag is derived from the source directory basename. On Windows guests, `VirtioFsSvc` mounts it automatically as a drive letter once the VM boots. Requires:
+
+- `virtiofsd` installed on the host (`apt install virtiofsd`)
+- WinFsp installed in the guest image (for Windows guests)
+- `memfd`-backed shared memory (added to the domain XML automatically when `mount` is set)
 
 ### Connection
 
@@ -114,6 +143,23 @@ The `image` field can be:
   - [Tart Guest Agent](https://github.com/cirruslabs/tart-guest-agent) installed and running
   - GitHub Actions runner installed
 - Sufficient disk space for VM clones
+
+### Shared Directories
+
+The `mounts` config field passes `--dir` flags to `tart run`, sharing host directories into the VM via virtiofs. This is the recommended approach for a persistent build cache.
+
+```yaml
+tart:
+  image: ghcr.io/cirruslabs/macos-sequoia-base:latest
+  mounts:
+    - name: vcpkg
+      source: /var/cache/vcpkg
+```
+
+How the share appears inside the guest depends on the guest OS:
+
+- **macOS guests:** Automatically mounted at `/Volumes/My Shared Files/<name>`. No setup needed.
+- **Linux guests:** Mount manually: `mount -t virtiofs com.apple.virtio-fs.automount /mnt/shared`. The `<name>` becomes a subdirectory under the mount point.
 
 ### Cleanup
 

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -8,3 +8,11 @@ runners:
     labels: [self-hosted, linux]
     docker:
       image: outrunner-runner:latest
+      # Optional: bind mount a host directory into every container.
+      # Useful for a persistent build cache (e.g. vcpkg, cargo, gradle).
+      # mounts:
+      #   - source: /var/cache/vcpkg
+      #     target: /opt/vcpkg-cache
+      #   - source: /var/cache/cargo
+      #     target: /opt/cargo-cache
+      #     read_only: false

--- a/examples/libvirt.yml
+++ b/examples/libvirt.yml
@@ -12,3 +12,9 @@ runners:
       runner_cmd: 'C:\actions-runner\run.cmd'
       cpus: 4
       memory: 8192
+      # Optional: share a host directory into the VM via virtiofs.
+      # Requires: virtiofsd installed on the host (apt install virtiofsd)
+      #           WinFsp installed in the guest image.
+      # The directory appears as a drive letter (e.g. Z:) in Windows.
+      # mount:
+      #   source: /var/cache/vcpkg

--- a/examples/mixed.yml
+++ b/examples/mixed.yml
@@ -9,6 +9,11 @@ runners:
     max_runners: 4
     docker:
       image: outrunner-runner:latest
+      # Optional: bind-mount a host directory into every container.
+      # Useful for a persistent build cache shared across ephemeral runners.
+      # mounts:
+      #   - source: /var/cache/build
+      #     target: /opt/build-cache
 
   windows:
     labels: [self-hosted, windows, x64]
@@ -18,6 +23,11 @@ runners:
       runner_cmd: 'C:\actions-runner\run.cmd'
       cpus: 4
       memory: 8192
+      # Optional: share a host directory into the VM via virtiofs.
+      # Appears as a drive letter (e.g. Z:) in Windows.
+      # Requires: virtiofsd on the host, WinFsp in the guest image.
+      # mount:
+      #   source: /var/cache/build
 
   macos:
     labels: [self-hosted, macos, arm64]
@@ -27,3 +37,11 @@ runners:
       runner_cmd: /actions-runner/run.sh
       cpus: 4
       memory: 8192
+      # Optional: share host directories into the VM via virtiofs.
+      # On macOS guests: accessible at /Volumes/My Shared Files/<name>
+      # On Linux guests: mount manually with:
+      #   mount -t virtiofs com.apple.virtio-fs.automount /mnt/shared
+      #   then access at /mnt/shared/<name>
+      # mounts:
+      #   - name: build-cache
+      #     source: /var/cache/build

--- a/examples/tart.yml
+++ b/examples/tart.yml
@@ -12,3 +12,14 @@ runners:
       runner_cmd: /actions-runner/run.sh
       cpus: 4
       memory: 8192
+      # Optional: share host directories into the VM via virtiofs (--dir).
+      # On macOS guests: accessible at /Volumes/My Shared Files/<name>
+      # On Linux guests: mount manually with:
+      #   mount -t virtiofs com.apple.virtio-fs.automount /mnt/shared
+      #   then access at /mnt/shared/<name>
+      # mounts:
+      #   - name: vcpkg
+      #     source: /var/cache/vcpkg
+      #   - name: cargo
+      #     source: /var/cache/cargo
+      #     read_only: false

--- a/provisioner/docker/docker.go
+++ b/provisioner/docker/docker.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
 )
 
@@ -91,6 +92,16 @@ func (d *Provisioner) Start(ctx context.Context, req *outrunner.RunnerRequest) e
 		_ = reader.Close()
 	}
 
+	var mounts []mount.Mount
+	for _, m := range dcfg.Mounts {
+		mounts = append(mounts, mount.Mount{
+			Type:     mount.TypeBind,
+			Source:   m.Source,
+			Target:   m.Target,
+			ReadOnly: m.ReadOnly,
+		})
+	}
+
 	resp, err := d.client.ContainerCreate(ctx,
 		&container.Config{
 			Image: img,
@@ -102,6 +113,7 @@ func (d *Provisioner) Start(ctx context.Context, req *outrunner.RunnerRequest) e
 		},
 		&container.HostConfig{
 			AutoRemove: true,
+			Mounts:     mounts,
 		},
 		nil, nil, req.Name,
 	)

--- a/provisioner/libvirt/libvirt.go
+++ b/provisioner/libvirt/libvirt.go
@@ -274,12 +274,18 @@ type domainXMLParams struct {
 	CPUs        int
 	MemoryMB    int
 	Network     string
+	MountSource string // empty = no virtiofs mount
+	MountTag    string // virtiofs tag (basename of source)
 }
 
 var domainTmpl = template.Must(template.New("domain").Parse(`<domain type='kvm'>
   <name>{{.Name}}</name>
   <memory unit='MiB'>{{.MemoryMB}}</memory>
-  <vcpu>{{.CPUs}}</vcpu>
+  <vcpu>{{.CPUs}}</vcpu>{{if .MountSource}}
+  <memoryBacking>
+    <source type='memfd'/>
+    <access mode='shared'/>
+  </memoryBacking>{{end}}
   <os firmware='efi'>
     <type arch='x86_64' machine='q35'>hvm</type>
     <boot dev='hd'/>
@@ -302,7 +308,12 @@ var domainTmpl = template.Must(template.New("domain").Parse(`<domain type='kvm'>
     </interface>
     <channel type='unix'>
       <target type='virtio' name='org.qemu.guest_agent.0'/>
-    </channel>
+    </channel>{{if .MountSource}}
+    <filesystem type='mount' accessmode='passthrough'>
+      <driver type='virtiofs'/>
+      <source dir='{{.MountSource}}'/>
+      <target dir='{{.MountTag}}'/>
+    </filesystem>{{end}}
     <serial type='pty'/>
     <console type='pty'/>
   </devices>
@@ -315,6 +326,10 @@ func renderDomainXML(name, overlayPath string, img *outrunner.LibvirtImage, netw
 		CPUs:        img.CPUs,
 		MemoryMB:    img.MemoryMB,
 		Network:     network,
+	}
+	if img.Mount != nil {
+		params.MountSource = img.Mount.Source
+		params.MountTag = filepath.Base(img.Mount.Source)
 	}
 
 	var buf strings.Builder

--- a/provisioner/tart/tart.go
+++ b/provisioner/tart/tart.go
@@ -57,7 +57,16 @@ func (t *Provisioner) Start(ctx context.Context, req *outrunner.RunnerRequest) e
 
 	go func() {
 		t.logger.Debug("Starting VM", slog.String("name", req.Name))
-		cmd := exec.CommandContext(runCtx, "tart", "run", "--no-graphics", req.Name)
+		args := []string{"run", "--no-graphics"}
+		for _, m := range img.Mounts {
+			dir := m.Name + ":" + m.Source
+			if m.ReadOnly {
+				dir += ":ro"
+			}
+			args = append(args, "--dir="+dir)
+		}
+		args = append(args, req.Name)
+		cmd := exec.CommandContext(runCtx, "tart", args...)
 		if err := cmd.Start(); err != nil {
 			if runCtx.Err() == nil {
 				t.logger.Error("Failed to start VM",


### PR DESCRIPTION
## Summary

- **Docker**: bind mounts via Docker SDK — `source`, `target`, `read_only` per entry
- **Tart**: shared directories via `tart run --dir` — `name`, `source`, `read_only` per entry; name becomes subdirectory under `/Volumes/My Shared Files/` on macOS guests
- **Libvirt**: single virtiofs mount via `virtiofsd` — `source` only; tag derived from basename; `memoryBacking`/`memfd` added to domain XML automatically

Primary use case: persistent build cache (vcpkg, cargo, gradle, etc.) shared across ephemeral runners — near-zero overhead, no network round-trip.

## What's included

- Config structs: `DockerMount`, `TartMount`, `LibvirtMount`
- Provisioner implementations in `docker.go`, `tart.go`, `libvirt.go`
- Tests: `TestLoadConfigMounts`, `TestLoadConfigNoMounts`
- Docs: configuration reference, provisioner reference, mixed-backends howto
- Examples: all four example configs updated with commented-out mount snippets