### PR TITLE
Fix: capture tart stderr on VM/runner failure

### DIFF
--- a/provisioner/tart/tart.go
+++ b/provisioner/tart/tart.go
@@ -3,8 +3,11 @@ package tart
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -12,6 +15,57 @@ import (
 
 	outrunner "github.com/NetwindHQ/gha-outrunner"
 )
+
+const maxStderrLog = 1024
+
+// tailBuffer is an io.Writer that keeps the last maxStderrLog bytes of output.
+type tailBuffer struct {
+	buf []byte
+	max int
+}
+
+func (t *tailBuffer) Write(p []byte) (int, error) {
+	t.buf = append(t.buf, p...)
+	if len(t.buf) > t.max {
+		t.buf = t.buf[len(t.buf)-t.max:]
+	}
+	return len(p), nil
+}
+
+func (t *tailBuffer) String() string {
+	return string(t.buf)
+}
+
+// stderrLog writes stderr to both a file and an in-memory tail buffer.
+type stderrLog struct {
+	file *os.File
+	tail *tailBuffer
+	w    io.Writer
+}
+
+func newStderrLog(name, label string) (*stderrLog, error) {
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("outrunner-%s-%s.log", label, name))
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("create stderr log %s: %w", path, err)
+	}
+	tail := &tailBuffer{max: maxStderrLog}
+	return &stderrLog{file: f, tail: tail, w: io.MultiWriter(f, tail)}, nil
+}
+
+func (s *stderrLog) Write(p []byte) (int, error) { return s.w.Write(p) }
+func (s *stderrLog) Path() string                { return s.file.Name() }
+func (s *stderrLog) Tail() string                { return strings.TrimSpace(s.tail.String()) }
+
+func (s *stderrLog) Close() {
+	_ = s.file.Close()
+}
+
+// CleanupFile removes the log file (call on success when there's nothing to debug).
+func (s *stderrLog) CleanupFile() {
+	_ = s.file.Close()
+	_ = os.Remove(s.file.Name())
+}
 
 // Provisioner creates ephemeral Tart VMs as GitHub Actions runners.
 // Uses `tart exec` via the guest agent for command execution.
@@ -66,22 +120,7 @@ func (t *Provisioner) Start(ctx context.Context, req *outrunner.RunnerRequest) e
 			args = append(args, "--dir="+dir)
 		}
 		args = append(args, req.Name)
-		cmd := exec.CommandContext(runCtx, "tart", args...)
-		if err := cmd.Start(); err != nil {
-			if runCtx.Err() == nil {
-				t.logger.Error("Failed to start VM",
-					slog.String("name", req.Name),
-					slog.String("error", err.Error()),
-				)
-			}
-			return
-		}
-		if err := cmd.Wait(); err != nil && runCtx.Err() == nil {
-			t.logger.Error("VM exited unexpectedly",
-				slog.String("name", req.Name),
-				slog.String("error", err.Error()),
-			)
-		}
+		t.runAndLog(runCtx, req.Name, "vm", args)
 	}()
 
 	// 4. Wait for guest agent
@@ -103,28 +142,49 @@ func (t *Provisioner) Start(ctx context.Context, req *outrunner.RunnerRequest) e
 	)
 
 	go func() {
-		cmd := exec.CommandContext(runCtx, "tart", "exec", req.Name,
-			runnerCmd, "--jitconfig", req.JITConfig,
-		)
-		if err := cmd.Start(); err != nil {
-			if runCtx.Err() == nil {
-				t.logger.Error("Failed to start runner",
-					slog.String("name", req.Name),
-					slog.String("error", err.Error()),
-				)
-			}
-			return
-		}
-		if err := cmd.Wait(); err != nil && runCtx.Err() == nil {
-			t.logger.Error("Runner exited with error",
-				slog.String("name", req.Name),
-				slog.String("error", err.Error()),
-			)
-		}
+		t.runAndLog(runCtx, req.Name, "runner",
+			[]string{"exec", req.Name, runnerCmd, "--jitconfig", req.JITConfig})
 	}()
 
 	t.logger.Info("Runner started in VM", slog.String("name", req.Name))
 	return nil
+}
+
+// runAndLog runs a tart command, streaming stderr to a temp file.
+// On failure it logs the last 1KB of stderr inline plus the full log path.
+// On success it removes the log file.
+func (t *Provisioner) runAndLog(ctx context.Context, name, label string, args []string) {
+	stderr, err := newStderrLog(name, label)
+	if err != nil {
+		t.logger.Error("Failed to create stderr log",
+			slog.String("name", name),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	cmd := exec.CommandContext(ctx, "tart", args...)
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		stderr.CleanupFile()
+		if ctx.Err() == nil {
+			t.logger.Error("Failed to start tart "+label,
+				slog.String("name", name),
+				slog.String("error", err.Error()),
+			)
+		}
+		return
+	}
+	if err := cmd.Wait(); err != nil && ctx.Err() == nil {
+		stderr.Close()
+		t.logger.Error("Tart "+label+" exited with error",
+			slog.String("name", name),
+			slog.String("error", err.Error()),
+			slog.String("stderr", stderr.Tail()),
+			slog.String("log", stderr.Path()),
+		)
+	} else {
+		stderr.CleanupFile()
+	}
 }
 
 func (t *Provisioner) Stop(ctx context.Context, name string) error {

--- a/provisioner/tart/tart.go
+++ b/provisioner/tart/tart.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -44,10 +43,9 @@ type stderrLog struct {
 }
 
 func newStderrLog(name, label string) (*stderrLog, error) {
-	path := filepath.Join(os.TempDir(), fmt.Sprintf("outrunner-%s-%s.log", label, name))
-	f, err := os.Create(path)
+	f, err := os.CreateTemp("", fmt.Sprintf("outrunner-%s-%s-*.log", label, name))
 	if err != nil {
-		return nil, fmt.Errorf("create stderr log %s: %w", path, err)
+		return nil, fmt.Errorf("create stderr log: %w", err)
 	}
 	tail := &tailBuffer{max: maxStderrLog}
 	return &stderrLog{file: f, tail: tail, w: io.MultiWriter(f, tail)}, nil
@@ -156,16 +154,19 @@ func (t *Provisioner) Start(ctx context.Context, req *outrunner.RunnerRequest) e
 func (t *Provisioner) runAndLog(ctx context.Context, name, label string, args []string) {
 	stderr, err := newStderrLog(name, label)
 	if err != nil {
-		t.logger.Error("Failed to create stderr log",
+		t.logger.Warn("Failed to create stderr log, running without capture",
 			slog.String("name", name),
 			slog.String("error", err.Error()),
 		)
-		return
 	}
 	cmd := exec.CommandContext(ctx, "tart", args...)
-	cmd.Stderr = stderr
+	if stderr != nil {
+		cmd.Stderr = stderr
+	}
 	if err := cmd.Start(); err != nil {
-		stderr.CleanupFile()
+		if stderr != nil {
+			stderr.CleanupFile()
+		}
 		if ctx.Err() == nil {
 			t.logger.Error("Failed to start tart "+label,
 				slog.String("name", name),
@@ -175,14 +176,19 @@ func (t *Provisioner) runAndLog(ctx context.Context, name, label string, args []
 		return
 	}
 	if err := cmd.Wait(); err != nil && ctx.Err() == nil {
-		stderr.Close()
-		t.logger.Error("Tart "+label+" exited with error",
+		attrs := []any{
 			slog.String("name", name),
 			slog.String("error", err.Error()),
-			slog.String("stderr", stderr.Tail()),
-			slog.String("log", stderr.Path()),
-		)
-	} else {
+		}
+		if stderr != nil {
+			stderr.Close()
+			attrs = append(attrs,
+				slog.String("stderr", stderr.Tail()),
+				slog.String("log", stderr.Path()),
+			)
+		}
+		t.logger.Error("Tart "+label+" exited with error", attrs...)
+	} else if stderr != nil {
 		stderr.CleanupFile()
 	}
 }

--- a/provisioner/tart/tart_test.go
+++ b/provisioner/tart/tart_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestTailBuffer_UnderMax(t *testing.T) {
 	tb := &tailBuffer{max: 16}
-	tb.Write([]byte("hello"))
+	_, _ = tb.Write([]byte("hello"))
 	if got := tb.String(); got != "hello" {
 		t.Fatalf("got %q, want %q", got, "hello")
 	}
@@ -15,7 +15,7 @@ func TestTailBuffer_UnderMax(t *testing.T) {
 
 func TestTailBuffer_ExactMax(t *testing.T) {
 	tb := &tailBuffer{max: 5}
-	tb.Write([]byte("abcde"))
+	_, _ = tb.Write([]byte("abcde"))
 	if got := tb.String(); got != "abcde" {
 		t.Fatalf("got %q, want %q", got, "abcde")
 	}
@@ -23,7 +23,7 @@ func TestTailBuffer_ExactMax(t *testing.T) {
 
 func TestTailBuffer_OverMax(t *testing.T) {
 	tb := &tailBuffer{max: 4}
-	tb.Write([]byte("abcdef"))
+	_, _ = tb.Write([]byte("abcdef"))
 	if got := tb.String(); got != "cdef" {
 		t.Fatalf("got %q, want %q", got, "cdef")
 	}
@@ -31,8 +31,8 @@ func TestTailBuffer_OverMax(t *testing.T) {
 
 func TestTailBuffer_MultipleWrites(t *testing.T) {
 	tb := &tailBuffer{max: 6}
-	tb.Write([]byte("abcd"))
-	tb.Write([]byte("efgh"))
+	_, _ = tb.Write([]byte("abcd"))
+	_, _ = tb.Write([]byte("efgh"))
 	if got := tb.String(); got != "cdefgh" {
 		t.Fatalf("got %q, want %q", got, "cdefgh")
 	}
@@ -56,8 +56,8 @@ func TestStderrLog_WritesFileAndTail(t *testing.T) {
 	}
 	defer sl.CleanupFile()
 
-	sl.Write([]byte("line one\n"))
-	sl.Write([]byte("line two\n"))
+	_, _ = sl.Write([]byte("line one\n"))
+	_, _ = sl.Write([]byte("line two\n"))
 
 	// Tail should contain the data
 	tail := sl.Tail()
@@ -89,7 +89,7 @@ func TestStderrLog_TailTruncates(t *testing.T) {
 		big[i] = 'x'
 	}
 	big[len(big)-1] = '!'
-	sl.Write(big)
+	_, _ = sl.Write(big)
 
 	tail := sl.tail.String()
 	if len(tail) != maxStderrLog {

--- a/provisioner/tart/tart_test.go
+++ b/provisioner/tart/tart_test.go
@@ -1,1 +1,124 @@
 package tart
+
+import (
+	"os"
+	"testing"
+)
+
+func TestTailBuffer_UnderMax(t *testing.T) {
+	tb := &tailBuffer{max: 16}
+	tb.Write([]byte("hello"))
+	if got := tb.String(); got != "hello" {
+		t.Fatalf("got %q, want %q", got, "hello")
+	}
+}
+
+func TestTailBuffer_ExactMax(t *testing.T) {
+	tb := &tailBuffer{max: 5}
+	tb.Write([]byte("abcde"))
+	if got := tb.String(); got != "abcde" {
+		t.Fatalf("got %q, want %q", got, "abcde")
+	}
+}
+
+func TestTailBuffer_OverMax(t *testing.T) {
+	tb := &tailBuffer{max: 4}
+	tb.Write([]byte("abcdef"))
+	if got := tb.String(); got != "cdef" {
+		t.Fatalf("got %q, want %q", got, "cdef")
+	}
+}
+
+func TestTailBuffer_MultipleWrites(t *testing.T) {
+	tb := &tailBuffer{max: 6}
+	tb.Write([]byte("abcd"))
+	tb.Write([]byte("efgh"))
+	if got := tb.String(); got != "cdefgh" {
+		t.Fatalf("got %q, want %q", got, "cdefgh")
+	}
+}
+
+func TestTailBuffer_ReportsFullWriteLen(t *testing.T) {
+	tb := &tailBuffer{max: 2}
+	n, err := tb.Write([]byte("abcdef"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 6 {
+		t.Fatalf("got n=%d, want 6", n)
+	}
+}
+
+func TestStderrLog_WritesFileAndTail(t *testing.T) {
+	sl, err := newStderrLog("test-vm", "vm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sl.CleanupFile()
+
+	sl.Write([]byte("line one\n"))
+	sl.Write([]byte("line two\n"))
+
+	// Tail should contain the data
+	tail := sl.Tail()
+	if tail != "line one\nline two" {
+		t.Fatalf("tail: got %q", tail)
+	}
+
+	// File should contain the data
+	sl.Close()
+	data, err := os.ReadFile(sl.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "line one\nline two\n" {
+		t.Fatalf("file: got %q", string(data))
+	}
+}
+
+func TestStderrLog_TailTruncates(t *testing.T) {
+	sl, err := newStderrLog("test-vm", "runner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sl.CleanupFile()
+
+	// Write more than maxStderrLog bytes
+	big := make([]byte, maxStderrLog+500)
+	for i := range big {
+		big[i] = 'x'
+	}
+	big[len(big)-1] = '!'
+	sl.Write(big)
+
+	tail := sl.tail.String()
+	if len(tail) != maxStderrLog {
+		t.Fatalf("tail len: got %d, want %d", len(tail), maxStderrLog)
+	}
+	if tail[len(tail)-1] != '!' {
+		t.Fatal("tail should end with the last byte written")
+	}
+
+	// File should have everything
+	sl.Close()
+	data, err := os.ReadFile(sl.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) != maxStderrLog+500 {
+		t.Fatalf("file len: got %d, want %d", len(data), maxStderrLog+500)
+	}
+}
+
+func TestStderrLog_CleanupRemovesFile(t *testing.T) {
+	sl, err := newStderrLog("test-vm", "cleanup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := sl.Path()
+	sl.CleanupFile()
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("file should be removed, got err: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Tart VM and runner failures previously only logged `exit status 1` with no stderr, making debugging impossible
- Stderr is now streamed to a temp file (e.g. `/tmp/outrunner-vm-<name>-1234567.log`) and the last 1KB is included inline in the error log
- Log files are automatically cleaned up on successful exit
- If the temp file can't be created, the command still runs — just without stderr capture
- Extracted shared `runAndLog` helper to eliminate duplication between the VM and runner goroutines
- Added unit tests for the tail buffer and stderr log

## Test plan
- [x] `make build` passes
- [x] `make lint` passes
- [x] `go test ./provisioner/tart/` — 8 tests pass