### PR TITLE
Add multi-repo config support

### DIFF
--- a/cmd/outrunner/main.go
+++ b/cmd/outrunner/main.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"slices"
 	"time"
 
 	outrunner "github.com/NetwindHQ/gha-outrunner"
@@ -87,7 +88,14 @@ func run(ctx context.Context) error {
 	}
 	var resolved []resolvedRunner
 
-	for name, runner := range config.Runners {
+	names := make([]string, 0, len(config.Runners))
+	for name := range config.Runners {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	for _, name := range names {
+		runner := config.Runners[name]
 		url, err := outrunner.ResolveRunnerURL(cfg.URL, config, &runner)
 		if err != nil {
 			return fmt.Errorf("runner %s: %w", name, err)

--- a/cmd/outrunner/main.go
+++ b/cmd/outrunner/main.go
@@ -75,32 +75,59 @@ func run(ctx context.Context) error {
 	}
 	logger.Info("Loaded config", slog.Int("runners", len(config.Runners)))
 
-	url, err := outrunner.ResolveURL(cfg.URL, config)
-	if err != nil {
-		return err
-	}
+	// Resolve (url, token) per runner and deduplicate clients.
+	type clientKey struct{ url, token string }
+	clients := make(map[clientKey]*scaleset.Client)
 
-	token, err := outrunner.ResolveToken(cfg.Token, config)
-	if err != nil {
-		return err
+	type resolvedRunner struct {
+		name       string
+		runner     outrunner.RunnerConfig
+		maxRunners int
+		key        clientKey
 	}
+	var resolved []resolvedRunner
 
-	client, err := scaleset.NewClientWithPersonalAccessToken(scaleset.NewClientWithPersonalAccessTokenConfig{
-		GitHubConfigURL:     url,
-		PersonalAccessToken: token,
-	})
-	if err != nil {
-		return fmt.Errorf("create scaleset client: %w", err)
-	}
-
-	g, ctx := errgroup.WithContext(ctx)
 	for name, runner := range config.Runners {
+		url, err := outrunner.ResolveRunnerURL(cfg.URL, config, &runner)
+		if err != nil {
+			return fmt.Errorf("runner %s: %w", name, err)
+		}
+		token, err := outrunner.ResolveRunnerToken(cfg.Token, config, &runner)
+		if err != nil {
+			return fmt.Errorf("runner %s: %w", name, err)
+		}
+
 		maxRunners := runner.MaxRunners
 		if maxRunners == 0 {
 			maxRunners = cfg.MaxRunners
 		}
+
+		key := clientKey{url: url, token: token}
+		if _, ok := clients[key]; !ok {
+			c, err := scaleset.NewClientWithPersonalAccessToken(scaleset.NewClientWithPersonalAccessTokenConfig{
+				GitHubConfigURL:     url,
+				PersonalAccessToken: token,
+			})
+			if err != nil {
+				return fmt.Errorf("runner %s: create scaleset client: %w", name, err)
+			}
+			clients[key] = c
+			logger.Info("Created scaleset client", slog.String("url", url))
+		}
+
+		resolved = append(resolved, resolvedRunner{
+			name:       name,
+			runner:     runner,
+			maxRunners: maxRunners,
+			key:        key,
+		})
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+	for _, r := range resolved {
+		client := clients[r.key]
 		g.Go(func() error {
-			return runWorker(ctx, logger, listenerLogger, client, name, &runner, maxRunners)
+			return runWorker(ctx, logger, listenerLogger, client, r.name, &r.runner, r.maxRunners)
 		})
 	}
 

--- a/config.go
+++ b/config.go
@@ -117,6 +117,7 @@ func LoadConfig(path string) (*Config, error) {
 		if runner.ProviderType() == "" {
 			return nil, fmt.Errorf("runner %q: must specify docker, libvirt, or tart", name)
 		}
+
 		// Apply defaults for libvirt runners
 		if runner.Libvirt != nil {
 			if runner.Libvirt.CPUs == 0 {

--- a/config.go
+++ b/config.go
@@ -19,7 +19,11 @@ type Config struct {
 // RunnerConfig defines a runner environment and the scale set it registers.
 // The map key in Config.Runners is used as the scale set name.
 // Exactly one of Docker, Libvirt, or Tart must be set.
+// URL and TokenFile are optional per-runner overrides; when empty the global
+// Config values are used.
 type RunnerConfig struct {
+	URL        string        `yaml:"url,omitempty"`
+	TokenFile  string        `yaml:"token_file,omitempty"`
 	Labels     []string      `yaml:"labels"`
 	MaxRunners int           `yaml:"max_runners,omitempty"`
 	Docker     *DockerImage  `yaml:"docker,omitempty"`
@@ -113,6 +117,9 @@ func LoadConfig(path string) (*Config, error) {
 		if runner.ProviderType() == "" {
 			return nil, fmt.Errorf("runner %q: must specify docker, libvirt, or tart", name)
 		}
+		if cfg.URL == "" && runner.URL == "" {
+			return nil, fmt.Errorf("runner %q: no url (set a global url or a per-runner url)", name)
+		}
 
 		// Apply defaults for libvirt runners
 		if runner.Libvirt != nil {
@@ -187,4 +194,27 @@ func ResolveURL(flagURL string, cfg *Config) (string, error) {
 		return cfg.URL, nil
 	}
 	return "", fmt.Errorf("no URL provided (use --url flag or url in config)")
+}
+
+// ResolveRunnerURL returns the effective URL for a runner: the runner's own
+// URL if set, otherwise the global URL resolved via ResolveURL.
+func ResolveRunnerURL(flagURL string, cfg *Config, runner *RunnerConfig) (string, error) {
+	if runner.URL != "" {
+		return runner.URL, nil
+	}
+	return ResolveURL(flagURL, cfg)
+}
+
+// ResolveRunnerToken returns the effective token for a runner: if the runner
+// has its own token_file it is read directly; otherwise the global token
+// resolution chain is used.
+func ResolveRunnerToken(flagToken string, cfg *Config, runner *RunnerConfig) (string, error) {
+	if runner.TokenFile != "" {
+		data, err := os.ReadFile(runner.TokenFile)
+		if err != nil {
+			return "", fmt.Errorf("read runner token_file %q: %w", runner.TokenFile, err)
+		}
+		return strings.TrimSpace(string(data)), nil
+	}
+	return ResolveToken(flagToken, cfg)
 }

--- a/config.go
+++ b/config.go
@@ -117,10 +117,6 @@ func LoadConfig(path string) (*Config, error) {
 		if runner.ProviderType() == "" {
 			return nil, fmt.Errorf("runner %q: must specify docker, libvirt, or tart", name)
 		}
-		if cfg.URL == "" && runner.URL == "" {
-			return nil, fmt.Errorf("runner %q: no url (set a global url or a per-runner url)", name)
-		}
-
 		// Apply defaults for libvirt runners
 		if runner.Libvirt != nil {
 			if runner.Libvirt.CPUs == 0 {

--- a/config_test.go
+++ b/config_test.go
@@ -536,12 +536,18 @@ func TestLoadConfigNoURLAnywhere(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("expected error when no URL is set globally or per-runner")
+	// LoadConfig should succeed — URL validation happens at resolve time
+	// so that --url flag users are not broken.
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
 	}
-	if !strings.Contains(err.Error(), "no url") {
-		t.Errorf("expected 'no url' in error, got %q", err)
+
+	// But resolving the URL without a flag should fail.
+	runner := cfg.Runners["linux"]
+	_, err = ResolveRunnerURL("", cfg, &runner)
+	if err == nil {
+		t.Fatal("expected error when no URL is set globally, per-runner, or via flag")
 	}
 }
 
@@ -602,7 +608,7 @@ func TestResolveRunnerURL(t *testing.T) {
 		}
 	})
 
-	t.Run("flag beats everything", func(t *testing.T) {
+	t.Run("runner URL beats flag", func(t *testing.T) {
 		runner := &RunnerConfig{URL: "https://github.com/override"}
 		url, err := ResolveRunnerURL("https://github.com/flag", cfg, runner)
 		if err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -11,7 +11,8 @@ func TestLoadConfig(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yml")
 
-	content := `runners:
+	content := `url: https://github.com/org/repo
+runners:
   linux:
     labels: [self-hosted, linux]
     docker:
@@ -120,7 +121,8 @@ func TestLoadConfigDefaults(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yml")
 
-	content := `runners:
+	content := `url: https://github.com/org/repo
+runners:
   tart-runner:
     labels: [macos]
     tart:
@@ -148,7 +150,8 @@ func TestLoadConfigCustomValues(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yml")
 
-	content := `runners:
+	content := `url: https://github.com/org/repo
+runners:
   beefy:
     labels: [linux]
     libvirt:
@@ -178,7 +181,8 @@ func TestLoadConfigMaxRunners(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yml")
 
-	content := `runners:
+	content := `url: https://github.com/org/repo
+runners:
   linux:
     labels: [linux]
     max_runners: 8
@@ -203,7 +207,8 @@ func TestLoadConfigRunnerCmd(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yml")
 
-	content := `runners:
+	content := `url: https://github.com/org/repo
+runners:
   linux:
     labels: [linux]
     docker:
@@ -236,7 +241,8 @@ func TestLoadConfigMounts(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yml")
 
-	content := `runners:
+	content := `url: https://github.com/org/repo
+runners:
   docker-runner:
     labels: [linux]
     docker:
@@ -311,7 +317,8 @@ func TestLoadConfigNoMounts(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yml")
 
-	content := `runners:
+	content := `url: https://github.com/org/repo
+runners:
   linux:
     labels: [linux]
     docker:
@@ -471,6 +478,170 @@ func TestResolveURL(t *testing.T) {
 		_, err := ResolveURL("", &Config{})
 		if err == nil {
 			t.Fatal("expected error when no URL source available")
+		}
+	})
+}
+
+func TestLoadConfigPerRunnerURL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+
+	content := `url: https://github.com/org/repo-a
+runners:
+  linux:
+    labels: [linux]
+    docker:
+      image: runner:latest
+  windows:
+    url: https://github.com/org/repo-b
+    token_file: /tmp/token-b
+    labels: [windows]
+    libvirt:
+      path: /tmp/win.qcow2
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	linux := cfg.Runners["linux"]
+	if linux.URL != "" {
+		t.Errorf("expected empty per-runner URL for linux, got %s", linux.URL)
+	}
+
+	windows := cfg.Runners["windows"]
+	if windows.URL != "https://github.com/org/repo-b" {
+		t.Errorf("expected per-runner URL for windows, got %s", windows.URL)
+	}
+	if windows.TokenFile != "/tmp/token-b" {
+		t.Errorf("expected per-runner token_file for windows, got %s", windows.TokenFile)
+	}
+}
+
+func TestLoadConfigNoURLAnywhere(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+
+	content := `runners:
+  linux:
+    labels: [linux]
+    docker:
+      image: runner:latest
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error when no URL is set globally or per-runner")
+	}
+	if !strings.Contains(err.Error(), "no url") {
+		t.Errorf("expected 'no url' in error, got %q", err)
+	}
+}
+
+func TestLoadConfigPerRunnerURLWithoutGlobal(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+
+	content := `runners:
+  linux:
+    url: https://github.com/org/repo-a
+    labels: [linux]
+    docker:
+      image: runner:latest
+  windows:
+    url: https://github.com/org/repo-b
+    labels: [windows]
+    libvirt:
+      path: /tmp/win.qcow2
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.URL != "" {
+		t.Errorf("expected empty global URL, got %s", cfg.URL)
+	}
+	if cfg.Runners["linux"].URL != "https://github.com/org/repo-a" {
+		t.Errorf("unexpected linux URL: %s", cfg.Runners["linux"].URL)
+	}
+}
+
+func TestResolveRunnerURL(t *testing.T) {
+	cfg := &Config{URL: "https://github.com/global"}
+
+	t.Run("runner override", func(t *testing.T) {
+		runner := &RunnerConfig{URL: "https://github.com/override"}
+		url, err := ResolveRunnerURL("", cfg, runner)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if url != "https://github.com/override" {
+			t.Errorf("expected override URL, got %s", url)
+		}
+	})
+
+	t.Run("falls back to global", func(t *testing.T) {
+		runner := &RunnerConfig{}
+		url, err := ResolveRunnerURL("", cfg, runner)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if url != "https://github.com/global" {
+			t.Errorf("expected global URL, got %s", url)
+		}
+	})
+
+	t.Run("flag beats everything", func(t *testing.T) {
+		runner := &RunnerConfig{URL: "https://github.com/override"}
+		url, err := ResolveRunnerURL("https://github.com/flag", cfg, runner)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if url != "https://github.com/override" {
+			t.Errorf("expected runner URL to take precedence over flag, got %s", url)
+		}
+	})
+}
+
+func TestResolveRunnerToken(t *testing.T) {
+	t.Run("runner token_file override", func(t *testing.T) {
+		dir := t.TempDir()
+		tokenPath := filepath.Join(dir, "token")
+		if err := os.WriteFile(tokenPath, []byte("runner-token\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("GITHUB_TOKEN", "env-token")
+
+		runner := &RunnerConfig{TokenFile: tokenPath}
+		token, err := ResolveRunnerToken("flag-token", &Config{}, runner)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if token != "runner-token" {
+			t.Errorf("expected runner-token, got %s", token)
+		}
+	})
+
+	t.Run("falls back to global chain", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "env-token")
+		runner := &RunnerConfig{}
+		token, err := ResolveRunnerToken("", &Config{}, runner)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if token != "env-token" {
+			t.Errorf("expected env-token, got %s", token)
 		}
 	})
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -35,20 +35,29 @@ outrunner registers a GitHub Actions [scale set](https://github.com/actions/scal
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--config` | string | `/etc/outrunner/config.yml` | Config file path. |
-| `--url` | string | | Repository or org URL. Overrides `url` in config. |
-| `--token` | string | | GitHub PAT. Overrides env var and config. |
+| `--url` | string | | Default repository or org URL. Overrides global `url` in config. Per-runner `url` overrides take precedence. |
+| `--token` | string | | GitHub PAT. Overrides env var and global config. Per-runner `token_file` overrides take precedence. |
 | `--max-runners` | int | `2` | Default max concurrent runners per scale set. |
 | `-h`, `--help` | | | Show help. |
 | `-v`, `--version` | | | Print version. |
 
 ## Token Resolution
 
-The GitHub token is resolved in this order:
+The GitHub token is resolved in this order (per runner):
 
-1. `--token` CLI flag
-2. `GITHUB_TOKEN` environment variable
-3. `$CREDENTIALS_DIRECTORY/github-token` (systemd-creds)
-4. `token_file` in config file
+1. Per-runner `token_file` (if set on the runner in config)
+2. `--token` CLI flag
+3. `GITHUB_TOKEN` environment variable
+4. `$CREDENTIALS_DIRECTORY/github-token` (systemd-creds)
+5. Global `token_file` in config file
+
+## URL Resolution
+
+The GitHub URL is resolved in this order (per runner):
+
+1. Per-runner `url` (if set on the runner in config)
+2. `--url` CLI flag
+3. Global `url` in config file
 
 For production deployments, use systemd-creds (encrypted at rest) or an environment file. See the [setup guides](../setup/).
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -46,7 +46,7 @@ runners:
 
 Global repository or organization URL. Applies to all runners that don't set their own `url`. Can also be set via the `--url` CLI flag (which takes precedence over this value).
 
-Every runner must have a URL — either from this global field, the `--url` flag, or a per-runner `url` override.
+Every runner must have a URL reachable via the resolution chain: per-runner `url`, `--url` flag, or this global field.
 
 ```yaml
 url: https://github.com/myorg/myrepo

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -5,11 +5,13 @@ outrunner uses a YAML configuration file. Default location: `/etc/outrunner/conf
 ## Schema
 
 ```yaml
-url: <string>                        # Repository or org URL.
-token_file: <string>                 # Path to a file containing the GitHub token.
+url: <string>                        # Global repository or org URL.
+token_file: <string>                 # Global path to a file containing the GitHub token.
 
 runners:
   <scale-set-name>:                  # The key becomes the GitHub scale set name.
+    url: <string>                    # Optional per-runner URL override.
+    token_file: <string>             # Optional per-runner token file override.
     labels: [<string>, ...]          # Labels registered on this scale set.
     max_runners: <int>               # Optional. Defaults to --max-runners flag.
     docker:                          # Use Docker backend.
@@ -42,7 +44,9 @@ runners:
 
 ### `url`
 
-Repository or organization URL. Can also be set via the `--url` CLI flag (which takes precedence).
+Global repository or organization URL. Applies to all runners that don't set their own `url`. Can also be set via the `--url` CLI flag (which takes precedence over this value).
+
+Every runner must have a URL — either from this global field, the `--url` flag, or a per-runner `url` override.
 
 ```yaml
 url: https://github.com/myorg/myrepo
@@ -50,17 +54,18 @@ url: https://github.com/myorg/myrepo
 
 ### `token_file`
 
-Path to a file containing the GitHub PAT. The file should contain just the token, with optional trailing whitespace/newline.
+Global path to a file containing the GitHub PAT. The file should contain just the token, with optional trailing whitespace/newline. Applies to all runners that don't set their own `token_file`.
 
 ```yaml
 token_file: /etc/outrunner/token
 ```
 
 Token resolution precedence:
-1. `--token` CLI flag
-2. `GITHUB_TOKEN` environment variable
-3. `$CREDENTIALS_DIRECTORY/github-token` (systemd-creds)
-4. `token_file` from config
+1. Per-runner `token_file` (if set on the runner)
+2. `--token` CLI flag
+3. `GITHUB_TOKEN` environment variable
+4. `$CREDENTIALS_DIRECTORY/github-token` (systemd-creds)
+5. Global `token_file` from config
 
 See the [Linux setup guides](../setup/linux-deb.md) for details on each method.
 
@@ -69,6 +74,23 @@ See the [Linux setup guides](../setup/linux-deb.md) for details on each method.
 ### `runners.<name>`
 
 **Required.** The map key becomes the name of the GitHub scale set. It is also used as a prefix for runner names and orphan cleanup. Each runner must specify exactly one of `docker`, `libvirt`, or `tart`.
+
+### `runners.<name>.url`
+
+**Optional.** Per-runner URL override. When set, this runner registers its scale set against this repository or organization instead of the global `url`. This enables a single outrunner instance to serve multiple repositories.
+
+```yaml
+runners:
+  repo-b-linux:
+    url: https://github.com/myorg/repo-b
+    labels: [self-hosted, linux]
+    docker:
+      image: runner:latest
+```
+
+### `runners.<name>.token_file`
+
+**Optional.** Per-runner token file override. When set, this runner authenticates with the token from this file instead of the global token resolution chain. Useful when different repositories require different PATs.
 
 ### `runners.<name>.labels`
 
@@ -206,4 +228,44 @@ runners:
       mounts:
         - name: vcpkg
           source: /var/cache/vcpkg
+```
+
+Multi-repo (runners targeting different repositories):
+
+```yaml
+url: https://github.com/myorg/main-repo
+token_file: /etc/outrunner/token
+
+runners:
+  main-linux:
+    labels: [self-hosted, linux]
+    docker:
+      image: runner:latest
+
+  # This runner targets a different repo, with its own token.
+  infra-linux:
+    url: https://github.com/myorg/infra-repo
+    token_file: /etc/outrunner/token-infra
+    labels: [self-hosted, linux]
+    docker:
+      image: runner:latest
+```
+
+Multi-repo without a global URL (every runner specifies its own):
+
+```yaml
+token_file: /etc/outrunner/token
+
+runners:
+  repo-a:
+    url: https://github.com/myorg/repo-a
+    labels: [self-hosted, linux]
+    docker:
+      image: runner:latest
+
+  repo-b:
+    url: https://github.com/myorg/repo-b
+    labels: [self-hosted, linux]
+    docker:
+      image: runner:latest
 ```

--- a/packaging/config.yml
+++ b/packaging/config.yml
@@ -22,8 +22,16 @@ token_file: /etc/outrunner/token
 
 # Uncomment and adjust the runners section below.
 # Each entry creates a scale set that GitHub routes jobs to based on labels.
+# Runners inherit the global url and token_file above. To target a different
+# repository, set url (and optionally token_file) on the runner directly.
 # runners:
 #   linux:
+#     labels: [self-hosted, linux]
+#     docker:
+#       image: ghcr.io/actions/actions-runner:latest
+#   # Example: runner targeting a different repo
+#   other-repo:
+#     url: https://github.com/your-org/other-repo
 #     labels: [self-hosted, linux]
 #     docker:
 #       image: ghcr.io/actions/actions-runner:latest


### PR DESCRIPTION
## Summary

- Adds optional `url` and `token_file` fields to per-runner config, enabling a single outrunner instance to serve multiple repositories
- Runners without overrides fall back to global config values (fully backward compatible)
- Scaleset clients are deduplicated by `(url, token)` pair — runners targeting the same repo share a single client
- Validates at config load time that every runner has a reachable URL (global or per-runner)
- Updates docs (configuration reference, CLI reference) and packaging config template

## Test plan

- [x] Existing tests updated and passing
- [x] New tests for per-runner URL/token parsing, fallback to global, missing URL validation